### PR TITLE
Add logging for reused/downloaded source files

### DIFF
--- a/cop_dem_tools.py
+++ b/cop_dem_tools.py
@@ -71,11 +71,12 @@ def fetch_cop_tiles(
                 found = p
                 break
         if found is not None:
+            console.log(f"[green]Using existing DEM tile → {found}")
             tif_paths.append(found)
             continue
 
         local = download_dir / fname
-        console.log(f"Fetching {url}")
+        console.log(f"Fetching {url} → {local}")
         with requests.get(url, stream=True, timeout=60) as r:
             r.raise_for_status()
             with open(local, "wb") as fp:

--- a/sentinel_utils.py
+++ b/sentinel_utils.py
@@ -9,8 +9,11 @@ import numpy as np
 import rasterio as rio
 import requests
 from PIL import Image
+from rich.console import Console
 
 SEARCH_URL = "https://earth-search.aws.element84.com/v1/search"
+
+console = Console()
 
 
 def _to_rfc3339(date: str, end: bool = False) -> str:
@@ -117,11 +120,13 @@ def download_bands(
                 break
 
         if found is not None:
+            console.log(f"[green]Using existing band file → {found}")
             paths[band] = found
             continue
 
         url = feature["assets"][asset]["href"]
         local = download_dir / filename
+        console.log(f"Fetching {url} → {local}")
         with requests.get(url, stream=True, timeout=60) as r:
             r.raise_for_status()
             with open(local, "wb") as f:


### PR DESCRIPTION
## Summary
- show message when Sentinel bands are reused or downloaded
- show message when Copernicus DEM tiles are reused or downloaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a0d29e81c832096f2202c79c791f0