### PR TITLE
Fix Copernicus DEM crop resolution

### DIFF
--- a/detect_hidden_sites.py
+++ b/detect_hidden_sites.py
@@ -85,7 +85,12 @@ def fetch_cop_tiles(bbox: tuple[float, float, float, float], out_dir: Path) -> P
     """Download and mosaic Copernicus tiles using :mod:`cop_dem_tools`."""
     tiles = _fetch_cop_tiles(bbox, out_dir)
     mosaic = mosaic_cop_tiles(tiles, out_dir / "cop90_mosaic.tif", bbox)
-    crop = crop_to_bbox(mosaic, bbox, out_dir / "cop90_crop.tif")
+    crop = crop_to_bbox(
+        mosaic,
+        bbox,
+        out_dir / "cop90_crop.tif",
+        resolution=0.0002695,
+    )
     return crop
 
 # ──────────────── GEDI helpers ─────────────────

--- a/pipeline.py
+++ b/pipeline.py
@@ -164,7 +164,12 @@ def step_fetch_data(
             download_dir=download_dir,
         )
         mosaic = mosaic_cop_tiles(tiles, base / "cop90_mosaic.tif", bbox)
-        crop = crop_to_bbox(mosaic, bbox, base / "cop90_crop.tif")
+        crop = crop_to_bbox(
+            mosaic,
+            bbox,
+            base / "cop90_crop.tif",
+            resolution=0.0002695,
+        )
         dem_path = crop
         if cfg.get("visualize", True):
             save_dem_png(mosaic, base / "1_copernicus_dem_mosaic_hillshade.png")

--- a/tests/test_cop_dem_tools.py
+++ b/tests/test_cop_dem_tools.py
@@ -80,6 +80,15 @@ def test_mosaic_and_crop(tmp_path: Path):
     assert png.exists()
 
 
+def test_crop_to_bbox_resample(tmp_path: Path):
+    t = tmp_path / "tile.tif"
+    _create_tile(t, 5, (0, 0, 1, 1))
+    crop = crop_to_bbox(t, (0, 0, 1, 1), tmp_path / "crop.tif", resolution=0.005)
+    with rio.open(crop) as src:
+        assert src.width == 200
+        assert src.height == 200
+
+
 def test_dem_to_overlay(tmp_path: Path):
     t = tmp_path / "tile.tif"
     _create_tile(t, 5, (0, 0, 1, 1))


### PR DESCRIPTION
## Summary
- allow crop_to_bbox to optionally resample to a target resolution
- resample Copernicus DEM crops to ~30 m in `pipeline.py` and `detect_hidden_sites.py`
- test crop_to_bbox resampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b6250c71883208eb197d9a5156ca4