### PR TITLE
Allow averaging multiple DEMs in residual relief

### DIFF
--- a/pipeline_config.yaml
+++ b/pipeline_config.yaml
@@ -42,6 +42,10 @@ step2:
 step3:
   enabled: true
   visualize: true
+  # Optional list of DEMs to subtract from the GEDI bare-earth surface.
+  # Specify by name: "cop", "srtm", "aw3d". Multiple entries will be averaged
+  # before subtraction.
+  dems: []
 
 step4:
   enabled: true

--- a/tests/test_pipeline_residual_step.py
+++ b/tests/test_pipeline_residual_step.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import rasterio as rio
+from rasterio.transform import from_bounds
+
+from pipeline import step_residual_relief
+
+
+def _create_raster(path: Path, value: float, bounds: tuple[float, float, float, float], size: int = 4) -> None:
+    transform = from_bounds(*bounds, size, size)
+    data = np.full((size, size), value, dtype=np.float32)
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+
+
+def _bearth_grid() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    xi = np.linspace(0, 1, 4)
+    yi = np.linspace(0, 1, 4)
+    xi_m, yi_m = np.meshgrid(xi, yi)
+    zi = np.full_like(xi_m, 10.0, dtype=np.float32)
+    return xi_m, yi_m, zi
+
+
+def test_step_residual_relief_name_mapping(tmp_path: Path) -> None:
+    xi, yi, zi = _bearth_grid()
+    cop = tmp_path / "cop90_crop.tif"
+    srtm = tmp_path / "srtm_crop.tif"
+    _create_raster(cop, 3, (0, 0, 1, 1))
+    _create_raster(srtm, 5, (0, 0, 1, 1))
+
+    cfg = {"enabled": True, "dems": ["cop", "srtm"], "visualize": False}
+
+    rrm = step_residual_relief(cfg, (xi, yi, zi), cop, tmp_path)
+
+    # average DEM value is 4
+    assert np.allclose(rrm[~np.isnan(rrm)], 6)
+
+

--- a/tests/test_residual_relief.py
+++ b/tests/test_residual_relief.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import numpy as np
+import rasterio as rio
+from rasterio.transform import from_bounds
+
+from detect_hidden_sites import residual_relief
+
+
+def _create_raster(path: Path, value: float, bounds: tuple[float, float, float, float], size: int = 4) -> None:
+    transform = from_bounds(*bounds, size, size)
+    data = np.full((size, size), value, dtype=np.float32)
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+
+
+def _bearth_grid() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    xi = np.linspace(0, 1, 4)
+    yi = np.linspace(0, 1, 4)
+    xi_m, yi_m = np.meshgrid(xi, yi)
+    zi = np.full_like(xi_m, 10.0, dtype=np.float32)
+    return xi_m, yi_m, zi
+
+
+def test_residual_relief_single(tmp_path: Path) -> None:
+    xi, yi, zi = _bearth_grid()
+    dem = tmp_path / "dem.tif"
+    _create_raster(dem, 3, (0, 0, 1, 1))
+
+    rrm = residual_relief((xi, yi, zi), dem)
+
+    assert np.allclose(rrm[~np.isnan(rrm)], 7)
+
+
+def test_residual_relief_average(tmp_path: Path) -> None:
+    xi, yi, zi = _bearth_grid()
+    d1 = tmp_path / "d1.tif"
+    d2 = tmp_path / "d2.tif"
+    _create_raster(d1, 2, (0, 0, 1, 1))
+    _create_raster(d2, 4, (0, 0, 1, 1))
+
+    rrm = residual_relief((xi, yi, zi), [d1, d2])
+
+    # average dem value is 3
+    assert np.allclose(rrm[~np.isnan(rrm)], 7)


### PR DESCRIPTION
## Summary
- extend `residual_relief` to support averaging multiple DEM rasters
- configure step 3 via `dems` list
- add tests for single and averaged DEM handling
- map DEM names to output files for step3

## Testing
- `pip install -e .`
- `pip install pyyaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684b6bbaeb8483209a0c5b85c2227026