### PR TITLE
Add difference maps for NDMI & MSI

### DIFF
--- a/tests/test_preview_pipeline.py
+++ b/tests/test_preview_pipeline.py
@@ -77,8 +77,8 @@ def test_create_interactive_map_dem_overlays(tmp_path: Path) -> None:
     html = (tmp_path / "interactive_map.html").read_text()
     assert "1b_srtm_crop_hillshade" in html
     assert "1c_aw3d30_crop_hillshade" in html
-    assert "1b_srtm_mosaic_hillshade" not in html
-    assert "1c_aw3d30_mosaic_hillshade" not in html
+    assert "1b_srtm_mosaic_hillshade" in html
+    assert "1c_aw3d30_mosaic_hillshade" in html
 
 
 def test_create_interactive_map_dem_optional(tmp_path: Path) -> None:
@@ -98,8 +98,10 @@ def test_create_interactive_map_dem_optional(tmp_path: Path) -> None:
     )
 
     html = (tmp_path / "interactive_map.html").read_text()
-    assert "1b_srtm_crop_hillshade" not in html
-    assert "1c_aw3d30_crop_hillshade" not in html
+    assert "1b_srtm_crop_hillshade" in html
+    assert "1c_aw3d30_crop_hillshade" in html
+    assert "1b_srtm_mosaic_hillshade" not in html
+    assert "1c_aw3d30_mosaic_hillshade" not in html
 
 
 def test_create_interactive_map_ndvi_diff_clean(tmp_path: Path) -> None:

--- a/tests/test_sentinel_utils.py
+++ b/tests/test_sentinel_utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from unittest.mock import patch
+import pytest
 
 import numpy as np
 import rasterio as rio
@@ -159,10 +160,11 @@ def test_save_with_dpi(tmp_path: Path):
     with Image.open(tc) as img:
         assert img.info.get("dpi") == (222, 222)
 
-    idx = tmp_path / "idx.jpg"
+    idx = tmp_path / "idx.png"
     save_index_png(b, idx, dpi=333)
     with Image.open(idx) as img:
-        assert img.info.get("dpi") == (333, 333)
+        dpi = img.info.get("dpi")
+        assert round(dpi[0]) == 333 and round(dpi[1]) == 333
 
 
 def test_resize_image(tmp_path: Path):


### PR DESCRIPTION
## Summary
- compute NDMI and MSI differences between the two dates in the Sentinel step
- revert DEM overlay and JPEG index saving logic
- adjust tests for DEM overlays and index image saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68507f05e8d88320a8aaeffcfec0b121