### PR TITLE
Add multi-bbox and force download options

### DIFF
--- a/detect_hidden_sites.py
+++ b/detect_hidden_sites.py
@@ -121,6 +121,7 @@ def fetch_gedi_points(
     threads: int = 4,
     verify_sizes: bool = True,  # Control size verification
     size_tolerance_pct: float = 0.5,  # Allow 0.5% difference in file size
+    force_download: bool = False,  # Automatically download without prompting
 ) -> gpd.GeoDataFrame:
     xmin, ymin, xmax, ymax = bbox
 
@@ -204,7 +205,10 @@ def fetch_gedi_points(
             f"{len(granules_to_download)} files need download "
             f"({to_dl_bytes/1_048_576:,.1f} MiB)"
         )
-        resp = input("Download missing files? [y/N] ").strip().lower()
+        if force_download:
+            resp = "y"
+        else:
+            resp = input("Download missing files? [y/N] ").strip().lower()
         if resp == "y":
             earthaccess.download(granules_to_download, download_dir, threads=threads)
         else:

--- a/pipeline_config.yaml
+++ b/pipeline_config.yaml
@@ -1,6 +1,8 @@
 # Example configuration for the refactored pipeline
 
-bbox: [-64.651794, -15.010122, -64.572144, -14.952414]
+bbox:
+  - [-64.651794, -15.010122, -64.572144, -14.952414]
+  - [-65.651794, -16.010122, -63.572144, -13.952414]
 out_dir: example_output
 
 fetch_data:
@@ -13,6 +15,7 @@ fetch_data:
     time_start: '2017-01-01'
     time_end: '2025-01-01'
     source_dirs: []
+    force_download: false
   visualize: true
 
 sentinel:

--- a/tests/test_pipeline_multi.py
+++ b/tests/test_pipeline_multi.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pipeline import run_pipeline
+
+
+def test_run_pipeline_multiple(tmp_path):
+    cfg = {
+        "bbox": [
+            [0, 0, 1, 1],
+            [1, 1, 2, 2],
+        ],
+        "out_dir": str(tmp_path),
+        "fetch_data": {"enabled": False},
+        "sentinel": {"enabled": False},
+        "srtm": {"enabled": False},
+        "aw3d": {"enabled": False},
+        "bare_earth": {"enabled": False},
+        "residual_relief": {"enabled": False},
+        "detect_anomalies": {"enabled": False},
+        "interactive_map": {"enabled": False},
+        "export_obj": {"enabled": False},
+        "export_xyz": {"enabled": False},
+    }
+    run_pipeline(cfg)
+    assert (tmp_path / "0_0_1_1").exists()
+    assert (tmp_path / "1_1_2_2").exists()


### PR DESCRIPTION
## Summary
- allow specifying multiple bounding boxes in the config
- create subdirectories for each bbox when running the pipeline
- support `force_download` option in `fetch_gedi_points`
- update example `pipeline_config.yaml`
- test multi bbox workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685349ddd1dc8320a02c8580190f80a2