### PR TITLE
Fix ChatGPT coordinate parsing

### DIFF
--- a/chatgpt_parser.py
+++ b/chatgpt_parser.py
@@ -6,7 +6,9 @@ from typing import List, Tuple
 _DET_RE = re.compile(r"ID\s*\d+.*?score\s*=\s*\d+(?:\.\d+)?", re.IGNORECASE)
 _SCORE_RE = re.compile(r"score\s*=\s*([\d.]+)", re.IGNORECASE)
 _COORD_RE = re.compile(
-    r"[\-−–]?\d+(?:\.\d+)?(?:°(?:\s*\d+(?:\.\d+)?(?:'\s*\d+(?:\.\d+)?)?\")?)?\s*[NSEW]?",
+    r"[-−–]?\d+(?:\.\d+)?"  # degrees with optional sign
+    r"(?:\s*[°º]\s*(?:\d+(?:\.\d+)?\s*(?:[′'’]\s*\d+(?:\.\d+)?\s*(?:[\"″”])?)?)?)?"  # optional minutes/seconds
+    r"\s*[NSEW]?",
     re.UNICODE,
 )
 

--- a/tests/test_chatgpt_parsing.py
+++ b/tests/test_chatgpt_parsing.py
@@ -37,3 +37,18 @@ def test_parse_chatgpt_description():
     detections = _parse_chatgpt_detections(text)
     assert detections[0][3] == "First detection description."
     assert detections[1][3] == "Second detection."
+
+
+def test_parse_chatgpt_spacing_and_symbols():
+    text = (
+        "ID 1 12\u00b0 41 \u2032 35 \u2033 S, 63\u00b0 52 \u2032 03 \u2033 W score = 1\n"
+        "ID 2 12.6842 \u00b0 S, 63.8756 \u00b0 W score = 2\n"
+        "ID 3 12\u00b0 41\u2032 00.9\u2033 S, 63\u00b0 52\u2032 34.3\u2033 W score = 3\n"
+    )
+    detections = _parse_chatgpt_detections(text)
+    assert detections[0][:3] == pytest.approx((-12.693056, -63.8675, 1.0))
+    assert detections[1][:3] == pytest.approx((-12.6842, -63.8756, 2.0))
+    assert detections[2][0] == pytest.approx(-12.683583, rel=1e-6)
+    assert detections[2][1] == pytest.approx(-63.876194, rel=1e-6)
+    assert detections[2][2] == pytest.approx(3.0)
+


### PR DESCRIPTION
## Summary
- broaden regex to handle spaced DMS coordinates and degree symbols
- add tests for spaced coordinate formats

## Testing
- `pytest tests/test_chatgpt_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_b_685b26feb6f483209995f36075ceef1f