### PR TITLE
Add combined bbox map option

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -965,6 +965,33 @@ def step_interactive_map(
         chatgpt_points=chatgpt_points,
     )
 
+    if cfg.get("combined_bboxes_map", True):
+        try:
+            import sys
+            import plot_all_bboxes
+
+            out_dir = base.parent
+            output_path = out_dir / "all_bboxes_map.html"
+            draw_path = out_dir / "exported_bboxes.yaml"
+
+            argv_bak = sys.argv[:]
+            sys.argv = [
+                "plot_all_bboxes.py",
+                str(out_dir),
+                "--output",
+                str(output_path),
+                "--draw-bboxes",
+                str(draw_path),
+            ]
+            if include_data_vis:
+                sys.argv.append("--include-data-vis")
+
+            plot_all_bboxes.main()
+        except Exception as exc:  # noqa: BLE001
+            console.log(f"[red]Failed to create combined map: {exc}")
+        finally:
+            sys.argv = argv_bak
+
 
 # ---------------------------------------------------------------------------
 # Main entry point

--- a/pipeline_config.yaml
+++ b/pipeline_config.yaml
@@ -71,6 +71,7 @@ interactive_map:
   include_full_sentinel: false
   include_full_srtm: false
   include_full_aw3d: false
+  combined_bboxes_map: true
 
 export_obj:
   enabled: true

--- a/tests/test_combined_map.py
+++ b/tests/test_combined_map.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pipeline import run_pipeline
+
+
+def _base_cfg(tmp_path: Path, combined: bool):
+    return {
+        "bbox": [[0, 0, 1, 1], [1, 1, 2, 2]],
+        "out_dir": str(tmp_path),
+        "fetch_data": {"enabled": False},
+        "sentinel": {"enabled": False},
+        "srtm": {"enabled": False},
+        "aw3d": {"enabled": False},
+        "bare_earth": {"enabled": False},
+        "residual_relief": {"enabled": False},
+        "detect_anomalies": {"enabled": False},
+        "chatgpt": {"enabled": False},
+        "interactive_map": {
+            "enabled": True,
+            "include_data_vis": False,
+            "combined_bboxes_map": combined,
+        },
+        "export_obj": {"enabled": False},
+        "export_xyz": {"enabled": False},
+    }
+
+
+def test_combined_map_created(tmp_path: Path) -> None:
+    cfg = _base_cfg(tmp_path, True)
+    run_pipeline(cfg)
+    assert (tmp_path / "all_bboxes_map.html").exists()
+
+
+def test_combined_map_disabled(tmp_path: Path) -> None:
+    cfg = _base_cfg(tmp_path, False)
+    run_pipeline(cfg)
+    assert not (tmp_path / "all_bboxes_map.html").exists()


### PR DESCRIPTION
## Summary
- add `combined_bboxes_map` flag for the interactive map step
- call `plot_all_bboxes` when enabled, exporting drawn bboxes path
- include option in default configuration
- test creation of combined map

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685dbcea75988320a6ab1134b579e06c