### PR TITLE
Add ChatGPT detection fallback

### DIFF
--- a/preview_pipeline.py
+++ b/preview_pipeline.py
@@ -32,6 +32,7 @@ from PIL import Image
 from sentinel_utils import save_image_with_metadata
 from pyproj import Transformer
 from rasterio.warp import Resampling, calculate_default_transform, reproject
+from chatgpt_parser import _parse_chatgpt_detections
 from scipy.interpolate import griddata
 from shapely.geometry import Point, box
 from shapely.ops import transform as shp_transform
@@ -895,6 +896,14 @@ def create_interactive_map(
     if anomalies is None and not Path(outdir).exists():
         print("No data for interactive map")
         return
+
+    if not chatgpt_points:
+        analysis_file = Path(outdir) / "chatgpt_analysis.txt"
+        if analysis_file.exists():
+            try:
+                chatgpt_points = _parse_chatgpt_detections(analysis_file.read_text())
+            except Exception as exc:  # pragma: no cover - ignore parse errors
+                print(f"Failed to parse {analysis_file}: {exc}")
 
     from data_vis import create_combined_map, load_reference_datasets
 

--- a/tests/test_preview_pipeline.py
+++ b/tests/test_preview_pipeline.py
@@ -138,3 +138,21 @@ def test_visualize_gedi_points_basic(tmp_path: Path) -> None:
         assert p.exists()
         assert read_bbox_metadata(p) == bbox
 
+
+def test_create_interactive_map_chatgpt_fallback(tmp_path: Path) -> None:
+    bbox = (0.0, 0.0, 1.0, 1.0)
+    (tmp_path / "chatgpt_analysis.txt").write_text("ID 1 0 S, 0 W score = 1.0")
+
+    create_interactive_map(
+        None,
+        pd.DataFrame(),
+        bbox,
+        tmp_path,
+        include_full_sentinel=False,
+        include_full_srtm=False,
+        include_full_aw3d=False,
+    )
+
+    html = (tmp_path / "interactive_map.html").read_text()
+    assert "ChatGPT Detections" in html
+


### PR DESCRIPTION
## Summary
- try to parse ChatGPT points from `chatgpt_analysis.txt` when not provided
- expose `_parse_chatgpt_detections` in `data_vis.create_combined_map`
- update `preview_pipeline.create_interactive_map` to load detections automatically
- test ChatGPT detection fallback in preview pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68619f09ebc08320a197d7d293772a49